### PR TITLE
Unified Options Hash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opt_struct (0.8.3)
+    opt_struct (0.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -61,4 +61,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.17.2

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -24,16 +24,7 @@ module OptStruct
           if options.key?(key)
             options[key]
           elsif defaults.key?(key)
-            default = defaults[key]
-            options[key] =
-              case default
-              when Proc
-                instance_exec(&default)
-              when Symbol
-                respond_to?(default) ? send(default) : default
-              else
-                default
-              end
+            options[key] = read_default_value(key)
           end
         end
       end
@@ -72,17 +63,8 @@ module OptStruct
     end
 
     def expect_arguments(*arguments)
-      check_reserved_words(arguments)
-
-      existing = expected_arguments.count
+      required(*arguments)
       expected_arguments.concat(arguments)
-
-      arguments.each_with_index do |arg, i|
-        n = i + existing
-        define_method(arg) { @arguments[n] }
-        define_method("#{arg}=") { |value| @arguments[n] = value }
-      end
-
     end
 
     def expected_arguments

--- a/lib/opt_struct/version.rb
+++ b/lib/opt_struct/version.rb
@@ -1,0 +1,3 @@
+module OptStruct
+  VERSION = "0.9.0"
+end

--- a/opt_struct.gemspec
+++ b/opt_struct.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opt_struct/version'
+
 Gem::Specification.new do |spec|
   spec.name          = "opt_struct"
-  spec.version       = "0.8.3"
+  spec.version       = OptStruct::VERSION
   spec.authors       = ["Carl Zulauf"]
   spec.email         = ["carl@linkleaf.com"]
 

--- a/spec/class_spec.rb
+++ b/spec/class_spec.rb
@@ -18,14 +18,13 @@ describe "OptStruct class usage spec" do
       value = subject.new(one: "foo", two: "bar", foo: "oof")
       expect(value.one).to eq("foo")
       expect(value.two).to eq("bar")
-      expect(value.options).to eq(foo: "oof")
+      expect(value.options).to eq(one: "foo", two: "bar", foo: "oof")
     end
 
     it "allows options to be grabbed via fetch" do
       value = subject.new(one: "foo", two: "bar", foo: "oof")
       expect(value.fetch(:foo)).to eq("oof")
       expect{value.fetch(:bar)}.to raise_error(KeyError)
-      expect{value.fetch(:one)}.to raise_error(KeyError)
       expect(value.fetch(:bar, :default)).to eq(:default)
       expect(value.fetch(:bar){:default}).to eq(:default)
     end

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -1,0 +1,47 @@
+describe "OptStruct instance methods usage" do
+  InstanceableClass = OptStruct.new(:arity_arg) do
+    required :required_arg
+    option :optional_arg
+    
+    def arity_up
+      options[:arity_arg].upcase
+    end
+    
+    def required_up
+      options[:required_arg].upcase
+    end
+    
+    def optional_up
+      options.fetch(:optional_arg, "default").upcase
+    end
+  end
+  
+  subject { InstanceableClass.new(arity_arg: "yaaa", required_arg: "yara") }
+  
+  it "allows use of #options to access required args" do
+    expect(subject.required_up).to eq("YARA")
+  end
+  
+  it "allows use of #options to access arity arguments" do
+    expect(subject.arity_up).to eq("YAAA")
+  end
+  
+  it "allows use of #options.fetch to provide default for optional args" do
+    expect(subject.optional_up).to eq("DEFAULT")
+  end
+  
+  context "with optional_arg supplied" do
+    subject do
+      InstanceableClass.new(
+        arity_arg:    "yaaa",
+        required_arg: "yara",
+        optional_arg: "yaoa"
+      )
+    end
+    
+    it "allows use of #options.fetch to safely access optional arguments" do
+      expect(subject.optional_up).to eq("YAOA")
+    end
+    
+  end
+end


### PR DESCRIPTION
Arguments are no longer in the `#arguments` array and are instead in the `#options` hash alongside all the normal keyword arguments. This allows unified access for things like `#options.fetch`.

Closes #1 