### PR TITLE
Return to Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.3
+  - 2.6.5
+before_install:
+  - gem install -N bundler -v 2.0.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 
-gem "pry"
-gem "sdoc"
+group :development, :test do
+  gem "pry"
+  gem "sdoc"
+  gem "rake"
+  gem "rspec"
+end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
 
-group :development, :test do
-  gem "pry"
-  gem "sdoc"
-  gem "rake"
-  gem "rspec"
-end
+gem "pry"
+gem "sdoc"
+gem "rake"
+gem "rspec"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,12 +34,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.14)
   opt_struct!
   pry
-  rake (>= 10.0)
-  rspec (>= 3.0)
+  rake
+  rspec
   sdoc
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/opt_struct.gemspec
+++ b/opt_struct.gemspec
@@ -16,8 +16,4 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n").grep(/^lib/)
   spec.files        += %w(README.md opt_struct.gemspec)
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", ">= 1.14"
-  spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "rspec", ">= 3.0"
 end


### PR DESCRIPTION
* Add `before_install` hook to travis CI to force bundler version for all rubies
* Drop EOL ruby 2.3 in travis config
* Move development gems out of gemspec and exclusively into Gemfile