### PR TITLE
Better handling of default values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,20 +14,20 @@ GEM
       method_source (~> 1.0)
     rake (13.0.6)
     rdoc (6.3.3)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.2)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.3)
-    sdoc (2.3.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    sdoc (2.3.1)
       rdoc (>= 5.0, < 6.4.0)
 
 PLATFORMS
@@ -41,4 +41,4 @@ DEPENDENCIES
   sdoc
 
 BUNDLED WITH
-   2.3.3
+   2.3.7

--- a/lib/opt_struct.rb
+++ b/lib/opt_struct.rb
@@ -5,6 +5,9 @@ require "opt_struct/instance_methods"
 module OptStruct
   RESERVED_WORDS = %i(class defaults options fetch check_required_args check_required_keys).freeze
 
+  # Default value object allows us to distinguish unspecified defaults from nil
+  DEFAULT = Object.new
+
   def self._inject_struct(target, source, args = [], **defaults, &callback)
     structs = Array(source.instance_variable_get(:@_opt_structs)).dup
     if args.any? || defaults.any? || block_given?

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -37,9 +37,9 @@ module OptStruct
       option_writer *keys, **options
     end
 
-    def option(key, default = nil, required: false, **options)
+    def option(key, default = OptStruct::DEFAULT, required: false, **options)
       default = options[:default] if options.key?(:default)
-      defaults[key] = default if default
+      defaults[key] = default unless default == OptStruct::DEFAULT
       required_keys << key if required
       option_accessor key, **options
     end
@@ -91,11 +91,9 @@ module OptStruct
 
     private
 
-    RESERVED_WORDS = %i(class defaults options fetch check_required_args check_required_keys)
-
     def check_reserved_words(words)
       Array(words).each do |word|
-        if RESERVED_WORDS.member?(word)
+        if OptStruct::RESERVED_WORDS.member?(word)
           raise ArgumentError, "Use of reserved word is not permitted: #{word.inspect}"
         end
       end

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -44,6 +44,18 @@ class DefaultProcWithChangingDefault < OptStruct.new
   end
 end
 
+class OptionsWithNilDefaults < OptStruct.new
+  option :implicit_nil
+  option :explicit_nil, nil
+  option :nil_block, -> { nil }
+  option :nil_method, :returns_nil
+  options :opt_list1, :opt_list2, opt_list_nil: nil
+
+  def returns_nil
+    nil
+  end
+end
+
 describe "OptStruct default values" do
   describe "using a symbol" do
     it "defaults to method return value when method exists" do
@@ -54,6 +66,13 @@ describe "OptStruct default values" do
     it "defaults to symbol if method does not exist" do
       expect(DefaultSymbolMethodDoesNotExist.new.foo).to eq(:bar)
       expect(DefaultSymbolMethodDoesNotExist.new.options[:foo]).to eq(:bar)
+    end
+
+    context "matching a method with nil return value" do
+      it "initializes the option with a nil value" do
+        expect(OptionsWithNilDefaults.new.nil_method).to eq(nil)
+        expect(OptionsWithNilDefaults.new.options.key?(:nil_method)).to eq(true)
+      end
     end
   end
 
@@ -81,6 +100,13 @@ describe "OptStruct default values" do
       expect(instance.fetch(:foo)).to eq(value)
       expect(instance.options[:foo]).to eq(value)
     end
+
+    context "with a nil return value" do
+      it "initializes the option with nil" do
+        expect(OptionsWithNilDefaults.new.nil_block).to eq(nil)
+        expect(OptionsWithNilDefaults.new.options.key?(:nil_block)).to eq(true)
+      end
+    end
   end
 
   describe "using a lambda" do
@@ -99,6 +125,40 @@ describe "OptStruct default values" do
     it "evaluates a method via symbol" do
       expect(DefaultProcAndSymbolUsingOptions.new.foo).to eq("test")
       expect(DefaultProcAndSymbolUsingOptions.new.options[:foo]).to eq("test")
+    end
+
+    it "initializes values with nil defaults" do
+      expect(OptionsWithNilDefaults.new.opt_list_nil).to eq(nil)
+      expect(OptionsWithNilDefaults.new.options.key?(:opt_list_nil)).to eq(true)
+    end
+
+    it "does not initialize values with no default provided" do
+      expect(OptionsWithNilDefaults.new.opt_list1).to eq(nil)
+      expect(OptionsWithNilDefaults.new.opt_list2).to eq(nil)
+      expect(OptionsWithNilDefaults.new.options.key?(:opt_list1)).to eq(false)
+      expect(OptionsWithNilDefaults.new.options.key?(:opt_list2)).to eq(false)
+    end
+  end
+
+  describe "using option syntax" do
+    context "with no explicit default" do
+      it "returns nil from option accessor" do
+        expect(OptionsWithNilDefaults.new.implicit_nil).to eq(nil)
+      end
+
+      it "does not initialize the option in the options hash" do
+        expect(OptionsWithNilDefaults.new.options.key?(:implicit_nil)).to eq(false)
+      end
+    end
+
+    context "with explicit default nil as second argument" do
+      it "returns nil from the option accessor" do
+        expect(OptionsWithNilDefaults.new.explicit_nil).to eq(nil)
+      end
+
+      it "initializes the option in the options hash" do
+        expect(OptionsWithNilDefaults.new.options.key?(:explicit_nil)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously not specifying a default value meant the option was initialized in the options hash with a nil value.

With this change, the option will no longer be initialized in the options hash if a default was not specified. Checks like `options.key?(:option_name)` will return false for options configured with no default (ie: `option :option_name`).

Option readers will still return `nil` for options with no default specified that haven't been set.

This change is enabled by introducing a default object (`OptStruct::DEFAULT`) as the "default default". If this object is detected as the default for an option, then initialization of the option is skipped. Since the options hash will still return `nil` for keys that haven't been initialized, option readers still return nil.