### PR TITLE
Track Defined Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 .ruby-version
+.tool-versions
 doc

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -7,8 +7,20 @@ module OptStruct
       end
     end
 
+    def defined_keys
+      @defined_keys ||= []
+    end
+
     def required_keys
       @required_keys ||= []
+    end
+
+    def expected_arguments
+      @expected_arguments ||= []
+    end
+
+    def defaults
+      @defaults ||= {}
     end
 
     def required(*keys, **options)
@@ -33,6 +45,7 @@ module OptStruct
 
     def option_accessor(*keys, **options)
       check_reserved_words(keys)
+      defined_keys.concat keys
       option_reader *keys, **options
       option_writer *keys, **options
     end
@@ -52,19 +65,11 @@ module OptStruct
       end
     end
 
-    def defaults
-      @defaults ||= {}
-    end
-
     def expect_arguments(*arguments)
       required(*arguments)
       expected_arguments.concat(arguments)
     end
     alias_method :expect_argument, :expect_arguments
-
-    def expected_arguments
-      @expected_arguments ||= []
-    end
 
     def init(meth = nil, &blk)
       add_callback(:init, meth || blk)

--- a/spec/class_methods_spec.rb
+++ b/spec/class_methods_spec.rb
@@ -1,0 +1,32 @@
+describe "Class methods added by OptStruct" do
+  subject do
+    OptStruct.new(:pos1, :pos2, opt1: :default, opt2: :default) do
+      required :opt3
+      option :opt4, default: :default
+    end
+  end
+
+  describe "required_keys" do
+    it "returns the keys for required options" do
+      expect(subject.required_keys).to eq(%i[pos1 pos2 opt3])
+    end
+  end
+
+  describe "defaults" do
+    it "returns a Hash containing current defaults, indexed by their keys" do
+      expect(subject.defaults).to eq({ opt1: :default, opt2: :default, opt4: :default })
+    end
+  end
+
+  describe "expected_arguments" do
+    it "returns the names of the positional arguments the struct expects" do
+      expect(subject.expected_arguments).to eq(%i[pos1 pos2])
+    end
+  end
+
+  describe "defined_keys" do
+    it "returns the names of all options explicitly defined" do
+      expect(subject.defined_keys).to eq(%i[pos1 pos2 opt1 opt2 opt3 opt4])
+    end
+  end
+end


### PR DESCRIPTION
There is currently no way to query for all defined options. This might be useful in situations where you want to determine which options are "extra", like a component that accepts known options and passes extras on to an HTML tag helper.

This PR adds `defined_keys` class method, to provide a basic building block that provides the names of all known options.