### PR TITLE
Add all instance methods to RESERVED_WORDS list

### DIFF
--- a/lib/opt_struct.rb
+++ b/lib/opt_struct.rb
@@ -3,7 +3,13 @@ require "opt_struct/module_methods"
 require "opt_struct/instance_methods"
 
 module OptStruct
-  RESERVED_WORDS = %i(class defaults options fetch check_required_args check_required_keys).freeze
+
+  RESERVED_WORDS = [
+    :class, :options,
+    *OptStruct::InstanceMethods.instance_methods,
+    *OptStruct::InstanceMethods.protected_instance_methods,
+    *OptStruct::InstanceMethods.private_instance_methods,
+  ].freeze
 
   # Default value object allows us to distinguish unspecified defaults from nil
   DEFAULT = Object.new

--- a/lib/opt_struct/instance_methods.rb
+++ b/lib/opt_struct/instance_methods.rb
@@ -29,24 +29,21 @@ module OptStruct
     def assign_defaults
       defaults.each do |key, default_value|
         next if options.key?(key)
-        options[key] = read_default_value(default_value)
+        options[key] =
+          case default_value
+          when Proc
+            instance_exec(&default_value)
+          when Symbol
+            respond_to?(default_value) ? send(default_value) : default_value
+          else
+            default_value
+          end
       end
     end
 
     def assign_arguments(args)
-      self.class.expected_arguments.map.with_index do |key, i|
+      self.class.expected_arguments.each_with_index do |key, i|
         options[key] = args[i] if args.length > i
-      end
-    end
-
-    def read_default_value(default)
-      case default
-      when Proc
-        instance_exec(&default)
-      when Symbol
-        respond_to?(default) ? send(default) : default
-      else
-        default
       end
     end
 

--- a/spec/class_methods_spec.rb
+++ b/spec/class_methods_spec.rb
@@ -29,4 +29,26 @@ describe "Class methods added by OptStruct" do
       expect(subject.defined_keys).to eq(%i[pos1 pos2 opt1 opt2 opt3 opt4])
     end
   end
+
+  describe "option" do
+    subject { OptStruct.new }
+
+    context "with a valid option" do
+      it "adds option to list of defined keys" do
+        expect { subject.option :valid }.to \
+          change { subject.defined_keys }.
+          from([]).
+          to([:valid])
+      end
+    end
+
+    context "with an option from the list of reserved words" do
+      it "raises an ArgumentError" do
+        expect { subject.option :fetch }.to raise_error(ArgumentError)
+        expect { subject.option :check_required_keys }.to raise_error(ArgumentError)
+        expect { subject.option :options }.to raise_error(ArgumentError)
+        expect { subject.option :run_callback }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds spec coverage including reserved words that previously weren't guarded. The defined methods are queried directly now, so there should be less issue with the actual methods getting out of sync with reserved words.

Also in-lines/eliminates `read_default_value` and eliminates an extra enum in `assign_arguments`. The former reduces the reserved words, and method count on empty structs. The latter may provide a tiny performance uplift.