### PR TITLE
Fix `inherited` breakage

### DIFF
--- a/lib/opt_struct.rb
+++ b/lib/opt_struct.rb
@@ -11,6 +11,12 @@ module OptStruct
     *OptStruct::InstanceMethods.private_instance_methods,
   ].freeze
 
+  # list of class instance variables defined/tracked by opt_struct
+  CLASS_IVARS = %i[
+    @defined_keys @required_keys @expected_arguments @defaults
+    @_callbacks @_opt_structs
+  ]
+
   # Default value object allows us to distinguish unspecified defaults from nil
   DEFAULT = Object.new
 

--- a/lib/opt_struct.rb
+++ b/lib/opt_struct.rb
@@ -15,11 +15,15 @@ module OptStruct
   DEFAULT = Object.new
 
   def self._inject_struct(target, source, args = [], **defaults, &callback)
-    structs = Array(source.instance_variable_get(:@_opt_structs)).dup
+    existing = source.instance_variable_get(:@_opt_structs)
+    structs = Array(existing).dup
+
     if args.any? || defaults.any? || block_given?
       structs << [args, defaults, callback]
     end
-    target.instance_variable_set(:@_opt_structs, structs)
+
+    target.instance_variable_set(:@_opt_structs, structs) if existing || structs.any?
+
     if target.is_a?(Class)
       target.instance_exec do
         extend ClassMethods

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -1,9 +1,10 @@
 module OptStruct
   module ClassMethods
     def inherited(subclass)
-      instance_variables.each do |v|
-        ivar = instance_variable_get(v)
-        subclass.send(:instance_variable_set, v, ivar.dup) if ivar
+      # intersection of defined vars and the ones we care about
+      (instance_variables & OptStruct::CLASS_IVARS).each do |ivar|
+        # copy them to the child class
+        subclass.send(:instance_variable_set, ivar, instance_variable_get(ivar).dup)
       end
     end
 

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -6,6 +6,7 @@ module OptStruct
         # copy them to the child class
         subclass.send(:instance_variable_set, ivar, instance_variable_get(ivar).dup)
       end
+      super(subclass)
     end
 
     def defined_keys

--- a/lib/opt_struct/module_methods.rb
+++ b/lib/opt_struct/module_methods.rb
@@ -23,6 +23,7 @@ module OptStruct
       expect_arguments
     ).each do |class_method|
       define_method(class_method) do |*args, **options|
+        @_opt_structs ||= []
         @_opt_structs << [[], {}, -> { send(class_method, *args, **options) }]
       end
     end


### PR DESCRIPTION
If a base class defines the `inherited` class method/hook, and then a sub class of that base class includes `OptStruct`, it overwrites the `inherited` method and does not call super. In this scenario the base class' `inherited` method is called before the overwrite occurs. However, if the sub class is sub classed again, creating a sub-sub class, then only `OptStruct`'s `inherited` method gets called.

`OptStruct` needs to define this method, but the solution is pretty simple: call `super` when we're done.

This PR also includes some safer and more explicit handling of class-level instance vars during inheritance.