### PR TITLE
Fix callback inheritance

### DIFF
--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -3,8 +3,15 @@ module OptStruct
     def inherited(subclass)
       # intersection of defined vars and the ones we care about
       (instance_variables & OptStruct::CLASS_IVARS).each do |ivar|
-        # copy them to the child class
-        subclass.send(:instance_variable_set, ivar, instance_variable_get(ivar).dup)
+        # copy each to the child class
+        value =
+          case ivar
+          when :@_callbacks # Hash that we need to duplicate deeper
+            instance_variable_get(ivar).transform_values(&:dup)
+          else
+            instance_variable_get(ivar).dup
+          end
+        subclass.send(:instance_variable_set, ivar, value)
       end
       super(subclass)
     end

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -83,7 +83,49 @@ class SubchildExpectingBehavior < ChildExpectingInheritedBehavior
   option :still_opt_structed, default: -> { :yes }
 end
 
+$breaker = true
+
+class BaseClassWithInit
+  include OptStruct
+
+  option :opt1
+  init { self.opt1 = :value1 }
+end
+
+class Child1WithInit < BaseClassWithInit
+  option :opt2
+  init { self.opt2 = :value2 }
+end
+
+class Child2WithInit < BaseClassWithInit
+  option :opt3
+  init { self.opt3 = :value3 }
+end
+
 describe "inheritance" do
+  context "when inherited with stacking callbacks" do
+    let(:parent) { BaseClassWithInit.new }
+    let(:child1) { Child1WithInit.new }
+    let(:child2) { Child2WithInit.new }
+
+    it "parent only has opt1 and it's set" do
+      expect(parent.opt1).to eq(:value1)
+      expect(parent.respond_to?(:opt2)).to eq(false)
+      expect(parent.respond_to?(:opt3)).to eq(false)
+    end
+
+    it "child1 has opt1 and opt2 present, but not opt3" do
+      expect(child1.opt1).to eq(:value1)
+      expect(child1.opt2).to eq(:value2)
+      expect(child1.respond_to?(:opt3)).to eq(false)
+    end
+
+    it "child2 has opt1 and opt3 present, but not opt2" do
+      expect(child2.opt1).to eq(:value1)
+      expect(child2.respond_to?(:opt2)).to eq(false)
+      expect(child2.opt3).to eq(:value3)
+    end
+  end
   context "when included in a class expecting inherited behavior from parent" do
     let(:parent) { BaseClassWithInheritedHook }
     let(:child) { SubchildExpectingBehavior }
@@ -99,6 +141,7 @@ describe "inheritance" do
       expect(subject.still_opt_structed).to eq(:yes)
     end
   end
+
   context "with more options" do
     subject { WithMoreOptions }
 


### PR DESCRIPTION
During inheritance, struct details are copied to the child by calling `dup` on each instance variable. This works for all of the details, except callbacks. Those are contained in a `Hash`, grouped by the callback type. Calling `dup` on the `@_callbacks` hash results in a new hash, but each value in the hash points to the same array as it's parent since the array values within the hash are not duplicated. This causes new callbacks to be added to both the parent class and the subclass, as well as be shared by all sub-classes of a single parent.

This commit changes the inherited behavior to handle `@_callbacks` in a special way, using `transform_values` to create a new hash with new arrays for each child to independently add to.