### PR TITLE
Remove EOL ruby versions from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', head, jruby, truffleruby]
+        ruby: ['3.3', '3.4', head, jruby, truffleruby]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,10 +24,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          # attempt to use default bundler for ruby version
-          # without this the version in Gemfile.lock is used, which is too new for ruby 2.7
-          bundler: default
+          bundler: 4.0.9
       - name: Install dependencies
-        run: bundle install
+        run: bundle config set without 'development docs' && bundle install
       - name: Run tests
         run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg
 .ruby-version
 .tool-versions
 doc
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,15 @@
 source 'https://rubygems.org'
 
 gem "ostruct"
-gem "pry"
-gem "sdoc"
 gem "rake"
 gem "rspec"
+
+group :development do
+  gem "pry"
+end
+
+group :docs do
+  gem "sdoc"
+end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -345,3 +345,7 @@ Available callbacks
 ## Inheritance, Expanded
 
 See `spec/inheritance_spec.rb` for examples of just how crazy you can get.
+
+## Ruby Versions
+
+This gem is expected to work with rubies as old as ~2.0, though official support and automated testing only covers non-EOL (End of Life) versions. Currently, that's ruby 3.3+. Tests are also performed against jruby and truffleruby to ensure portability.

--- a/Rakefile
+++ b/Rakefile
@@ -1,20 +1,27 @@
 require "bundler/setup"
-require "sdoc"
-require "pry"
 require "opt_struct"
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-require "rdoc/task"
+
+# These gems are not part of the main/minimum bundle.
+# If we don't find them we should ignore and move on.
+begin
+  require "pry"
+  require "sdoc"
+  require "rdoc/task"
+rescue LoadError; end
 
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
-RDoc::Task.new do |t|
-  t.rdoc_dir = "doc"
-  t.rdoc_files.include("README.md", "lib/**/*.rb")
-  t.options << "--format=sdoc"
-  t.template = "rails"
+if defined?(RDoc)
+  RDoc::Task.new do |t|
+    t.rdoc_dir = "doc"
+    t.rdoc_files.include("README.md", "lib/**/*.rb")
+    t.options << "--format=sdoc"
+    t.template = "rails"
+  end
 end
 
 task :console do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 require "bundler/setup"
-require "pry"
 require "opt_struct"
+
+# Part of the development bundle. Ignore if we don't find.
+begin
+  require "pry"
+rescue LoadError; end
 
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :expect }


### PR DESCRIPTION
Older versions of ruby that are EOL back to at least 2.7 are assumed to be supported on a best efforts basis, but CI will use fully supported rubies.

Also moves gems not needed for CI into a group in Gemfile and excludes that group in CI build.