### PR TITLE
Add default block support to OptStruct#option

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['3.3', '3.4', head, jruby, truffleruby]
+        ruby: ['3.3', '3.4', "4.0", jruby, truffleruby]
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/opt_struct/class_methods.rb
+++ b/lib/opt_struct/class_methods.rb
@@ -59,9 +59,14 @@ module OptStruct
       option_writer *keys, **options
     end
 
-    def option(key, default = OptStruct::DEFAULT, required: false, **options)
-      default = options[:default] if options.key?(:default)
-      defaults[key] = default unless default == OptStruct::DEFAULT
+    def option(key, default = OptStruct::DEFAULT, required: false, **options, &default_block)
+      if options.key?(:default)
+        defaults[key] = options[:default]
+      elsif default != OptStruct::DEFAULT
+        defaults[key] = default
+      elsif default_block
+        defaults[key] = default_block
+      end
       required_keys << key if required
       option_accessor key, **options
     end

--- a/lib/opt_struct/instance_methods.rb
+++ b/lib/opt_struct/instance_methods.rb
@@ -36,7 +36,11 @@ module OptStruct
         options[key] =
           case default_value
           when Proc
-            instance_exec(&default_value)
+            if default_value.arity == 0
+              instance_exec(&default_value)
+            else
+              instance_exec(self, &default_value)
+            end
           when Symbol
             respond_to?(default_value, true) ? send(default_value) : default_value
           else

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -24,6 +24,20 @@ class DefaultProc < OptStruct.new
   option :foo, default: -> { "bar" }
 end
 
+class DefaultSymbolToProcAsBlock < OptStruct.new
+  option :foo, &:bar
+
+  def bar
+    "bar"
+  end
+end
+
+class DefaultBlock < OptStruct.new
+  option(:foo) { bar }
+
+  def bar = "bar"
+end
+
 class DefaultLambda < OptStruct.new
   option :foo, default: lambda { "bar" }
 end
@@ -114,6 +128,15 @@ describe "OptStruct default values" do
       expect(instance.foo).to eq(value)
       expect(instance.fetch(:foo)).to eq(value)
       expect(instance.options[:foo]).to eq(value)
+    end
+
+    it "allows proc to be passed as a block" do
+      expect(DefaultSymbolToProcAsBlock.new.foo).to eq("bar")
+      expect(DefaultSymbolToProcAsBlock.new.options[:foo]).to eq("bar")
+    end
+
+    it "allows default blocks" do
+      expect(DefaultBlock.new.foo).to eq("bar")
     end
 
     context "with a nil return value" do

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -83,8 +83,6 @@ class SubchildExpectingBehavior < ChildExpectingInheritedBehavior
   option :still_opt_structed, default: -> { :yes }
 end
 
-$breaker = true
-
 class BaseClassWithInit
   include OptStruct
 

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -68,7 +68,6 @@ describe "OptStruct instance methods usage" do
     subject { InstanceableClass.new(arity_arg: 1, private_required_arg: 1) }
 
     it "raises an ArgumentError" do
-      # binding.pry
       expect { subject }.to raise_error(ArgumentError)
     end
   end


### PR DESCRIPTION
These examples would previously fail, but will now work:

```ruby
OptStruct.new do
  option :name, &:random_name
  option(:email) { assigned_email }

  def random_name = %w[Sally Jeff].sample
  def assigned_email = "new@example.com"
end
```